### PR TITLE
Initialise idnumber property to resolve issue #5 test failure

### DIFF
--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -72,6 +72,8 @@ class qtype_ddmatch_test extends advanced_testcase {
         $q->createdby = $USER->id;
         $q->modifiedby = $USER->id;
 
+        $q->idnumber = '';
+
         $q->options = new stdClass();
         $q->options->shuffleanswers = false;
         test_question_maker::set_standard_combined_feedback_fields($q->options);


### PR DESCRIPTION
Initialise idnumber property of question object in get_test_question_data() to resolve unit test failure reported in issue #5 