### PR TITLE
M3.11 compatibility fixes for Behat/PHPUnit tests

### DIFF
--- a/tests/behat/add.feature
+++ b/tests/behat/add.feature
@@ -16,7 +16,7 @@ Feature: Test creating a drag and drop matching question
       | teacher1 | C1     | editingteacher |
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
-    And I navigate to "Question bank" node in "Course administration"
+    And I navigate to "Question bank" in current page administration
 
   Scenario: Create a drag and drop matching question
     When I add a "Drag-and-Drop Matching" question filling the form with:

--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -31,8 +31,8 @@ Feature: Test duplicating a quiz containing a Drag and drop matching question
       | Confirmation | Filename | test_backup.mbz |
     And I restore "test_backup.mbz" backup into a new course using this options:
       | Schema | Course name | Course 2 |
-    And I navigate to "Question bank" node in "Course administration"
-    And I click on "Edit" "link" in the "ddmatch-001" "table_row"
+    And I navigate to "Question bank" in current page administration
+    And I choose "Edit question" action for "ddmatch-001" in the question bank
     Then the following fields match these values:
       | Question name                      | ddmatch-001                      |
       | Question text                      | Classify the animals.            |

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -22,11 +22,11 @@ Feature: Test editing a Drag and drop matching question
       | Test questions   | ddmatch | Ddmatching for editing | foursubq |
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
-    And I navigate to "Question bank" node in "Course administration"
+    And I navigate to "Question bank" in current page administration
 
   @javascript @_switch_window
   Scenario: Edit a Drag and drop matching question
-    When I click on "Edit" "link" in the "Ddmatching for editing" "table_row"
+    When I choose "Edit question" action for "Ddmatching for editing" in the question bank
     And I set the following fields to these values:
       | Question name | |
     And I press "id_submitbutton"
@@ -35,14 +35,14 @@ Feature: Test editing a Drag and drop matching question
       | Question name | Edited Ddmatching name |
     And I press "id_submitbutton"
     Then I should see "Edited Ddmatching name"
-    When I click on "Edit" "link" in the "Edited Ddmatching name" "table_row"
+    When I choose "Edit question" action for "Edited Ddmatching name" in the question bank
     And I set the following fields to these values:
       | Shuffle    | 0   |
       | Question 2 | dog |
       | Question 4 | fly |
     And I press "id_submitbutton"
     Then I should see "Edited Ddmatching name"
-    When I click on "Preview" "link" in the "Edited Ddmatching name" "table_row"
+    When I choose "Preview" action for "Edited Ddmatching name" in the question bank
     And I switch to "questionpreview" window
     Then I should see "frog"
     And I should see "dog"

--- a/tests/behat/export.feature
+++ b/tests/behat/export.feature
@@ -24,10 +24,11 @@ Feature: Test exporting Drag and drop matching questions
     And I am on "Course 1" course homepage
 
   Scenario: Export a Drag and drop matching question
-    When I navigate to "Export" node in "Course administration > Question bank"
+    When I navigate to "Question bank" in current page administration
+    And I click on "Export" "link"
     And I set the field "id_format_xml" to "1"
     And I press "Export questions to file"
-    Then following "click here" should download between "1600" and "1700" bytes
+    Then following "click here" should download between "1600" and "1800" bytes
     # If the download step is the last in the scenario then we can sometimes run
     # into the situation where the download page causes a http redirect but behat
     # has already conducted its reset (generating an error). By putting a logout

--- a/tests/behat/import.feature
+++ b/tests/behat/import.feature
@@ -19,7 +19,8 @@ Feature: Test importing Drag and drop matching questions
 
   @javascript @_file_upload
   Scenario: import Drag and drop matching question.
-    When I navigate to "Import" node in "Course administration > Question bank"
+    When I navigate to "Question bank" in current page administration
+    And I click on "Import" "link"
     And I set the field "id_format_xml" to "1"
     And I upload "question/type/ddmatch/tests/fixtures/qtype_sample_ddmatch.xml" file to "Import" filemanager
     And I press "id_submitbutton"

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -90,6 +90,7 @@ class qtype_ddmatch_test_helper extends question_test_helper {
         $q->penalty = 0.3333333;
         $q->length = 1;
         $q->hidden = 0;
+        $q->idnumber = null;
         $q->createdby = $USER->id;
         $q->modifiedby = $USER->id;
 

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -23,6 +23,13 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_ddmatch;
+
+use advanced_testcase;
+use qtype_ddmatch_test_helper;
+use question_attempt_step;
+use question_classified_response;
+use question_state;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -37,7 +44,7 @@ require_once($CFG->dirroot . '/question/type/ddmatch/tests/helper.php');
  * @copyright  2009 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_ddmatch_question_test extends advanced_testcase {
+class question_test extends advanced_testcase {
 
     public function test_get_expected_data() {
         $question = qtype_ddmatch_test_helper::make_a_ddmatching_question();
@@ -135,12 +142,12 @@ class qtype_ddmatch_question_test extends advanced_testcase {
         $ddmatch = qtype_ddmatch_test_helper::make_a_ddmatching_question();
         $ddmatch->start_attempt(new question_attempt_step(), 1);
         $qsummary = $ddmatch->get_question_summary();
-        $this->assertRegExp('/' . preg_quote($ddmatch->questiontext) . '/', $qsummary);
+        $this->assertMatchesRegularExpression('/' . preg_quote($ddmatch->questiontext, '/') . '/', $qsummary);
         foreach ($ddmatch->stems as $stem) {
-            $this->assertRegExp('/' . preg_quote($stem) . '/', $qsummary);
+            $this->assertMatchesRegularExpression('/' . preg_quote($stem, '/') . '/', $qsummary);
         }
         foreach ($ddmatch->choices as $choice) {
-            $this->assertRegExp('/' . preg_quote($choice) . '/', $qsummary);
+            $this->assertMatchesRegularExpression('/' . preg_quote($choice, '/') . '/', $qsummary);
         }
     }
 
@@ -151,7 +158,7 @@ class qtype_ddmatch_question_test extends advanced_testcase {
 
         $summary = $ddmatch->summarise_response(array('sub0' => 2, 'sub1' => 1));
 
-        $this->assertRegExp('/Dog -> \w+; Frog -> \w+/', $summary);
+        $this->assertMatchesRegularExpression('/Dog -> \w+; Frog -> \w+/', $summary);
     }
 
     public function test_classify_response() {

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -23,6 +23,13 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_ddmatch;
+
+use advanced_testcase;
+use qtype_ddmatch;
+use question_possible_response;
+use stdClass;
+use test_question_maker;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -37,15 +44,15 @@ require_once($CFG->dirroot . '/question/type/ddmatch/questiontype.php');
  * @copyright  2009 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_ddmatch_test extends advanced_testcase {
+class questiontype_test extends advanced_testcase {
     /** @var qtype_ddmatch instance of the question type class to test. */
     protected $qtype;
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->qtype = new qtype_ddmatch();
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         $this->qtype = null;
     }
 
@@ -67,6 +74,7 @@ class qtype_ddmatch_test extends advanced_testcase {
         $q->stamp = make_unique_id_code();
         $q->version = make_unique_id_code();
         $q->hidden = 0;
+        $q->idnumber = null;
         $q->timecreated = time();
         $q->timemodified = time();
         $q->createdby = $USER->id;
@@ -116,7 +124,7 @@ class qtype_ddmatch_test extends advanced_testcase {
 
     public function test_get_random_guess_score() {
         $q = $this->get_test_question_data();
-        $this->assertEquals(0.33333333333333331, $this->qtype->get_random_guess_score($q), '', 0.0000001);
+        $this->assertEqualsWithDelta(0.3333333, $this->qtype->get_random_guess_score($q), 0.0000001);
     }
 
     public function test_get_possible_responses() {

--- a/tests/upgradelibnewqe_test.php
+++ b/tests/upgradelibnewqe_test.php
@@ -23,6 +23,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_ddmatch;
+
+use question_attempt_upgrader_test_base;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -36,7 +39,7 @@ require_once($CFG->dirroot . '/question/engine/upgrade/tests/helper.php');
  * @copyright  2009 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_ddmatch_attempt_upgrader_test extends question_attempt_upgrader_test_base {
+class upgradelibnewqe_test extends question_attempt_upgrader_test_base {
 
     public function test_ddmatch_deferredfeedback_history6220() {
         $quiz = (object) array(

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -24,6 +24,13 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_ddmatch;
+
+use qbehaviour_walkthrough_test_base;
+use qtype_ddmatch_test_helper;
+use question_hint_with_parts;
+use question_pattern_expectation;
+use question_state;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -37,7 +44,7 @@ require_once($CFG->dirroot . '/question/type/ddmatch/tests/helper.php');
  * @copyright  2010 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_ddmatch_walkthrough_test extends qbehaviour_walkthrough_test_base {
+class walkthrough_test extends qbehaviour_walkthrough_test_base {
 
     public function test_deferred_feedback_unanswered() {
 


### PR DESCRIPTION
These changes were needed for the Behat / PHPUnit tests to pass in Moodle 3.11 - some of them will break compatibility with older versions of Moodle (for test running), so you may want to consider how you manage the branches when merging.