### PR TITLE
Issue-34: fix deprecated function assertRegExp in phpUnit tests

### DIFF
--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -19,9 +19,9 @@
  *
  * @package    qtype
  * @subpackage ddmatch
- * 
+ *
  * @author DualCube <admin@dualcube.com>
- * @copyright  2007 DualCube (https://dualcube.com) 
+ * @copyright  2007 DualCube (https://dualcube.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -149,7 +149,7 @@ class question_test extends advanced_testcase {
             $this->assertMatchesRegularExpression('/' . preg_quote($stem, '/') . '/', $qsummary);
         }
         foreach ($ddmatch->choices as $choice) {
-            $this->assertRegExp('/' . preg_quote($choice) . '/', $qsummary);
+            $this->assertMatchesRegularExpression('/' . preg_quote($choice) . '/', $qsummary);
         }
     }
 


### PR DESCRIPTION
Pull-Request for Issue #34 and some minor changes to make codechecker happy.